### PR TITLE
Update package info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - POST and DELETE methods
 - SHACL validator to validate different layers of metadata
-- Support for SPARQL database store, such as Virtuoso RDF Triple Store
+- Support for SPARQL database, such as Virtuoso RDF Triple Store
 - Docker compose file
 - Running in production mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.7.0] - 2020-06-05
 ### Added
 - POST and DELETE methods
-- Support for common RDF formats (MIME types) in GET and POST methods
 - SHACL validator to validate different layers of metadata
-- Support for SPARQL database store
-- Docker file and docker compose file
+- Support for SPARQL database store, such as Virtuoso RDF Triple Store
+- Docker compose file
 - Running in production mode
 
 ### Changed
-- GET and POST methods
+- Improved GET and POST methods
+- Updated support for common RDF serializations
 - Removed loading metadata for the command tool `fdp-run`
 - Removed support for INI-based configuration files
-- Big updates on tests
-- Documentation in README
+- Updated docker file
+- Improved unit testing
+- Updated README
 - Use Bottle and Paste for production run
 
 ## [0.6.0] - 2020-02-10
@@ -26,7 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Automatic Swagger API (OpenAPI) generation (via `flask-restplus`).
 
 ### Changed
-- Documentation in REAME
+- Documentation in README
 - Use Flask instead of Bottle
 
 ### Fixed

--- a/fdp/__init__.py
+++ b/fdp/__init__.py
@@ -6,7 +6,7 @@ from .__version__ import __version__
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__author__ = "Rajaram Kaliyaperumal, Arnold Kuzniar, Carlos Martinez-Ortiz"
+__author__ = "Rajaram Kaliyaperumal, Arnold Kuzniar, Cunliang Geng, Carlos Martinez-Ortiz"
 __email__ = 'c.martinez@esciencecenter.nl'
 __status__ = 'beta'
 __license__ = 'Apache License, Version 2.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description-file = README.md
 
 [coverage:run]
 branch = True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description="Python implementation of FAIR Data Point",
     long_description=readme + '\n\n',
     long_description_content_type='text/markdown',
-    author="Rajaram Kaliyaperumal, Arnold Kuzniar, Carlos Martinez-Ortiz",
+    author="Rajaram Kaliyaperumal, Arnold Kuzniar, Cunliang Geng, Carlos Martinez-Ortiz",
     author_email='c.martinez@esciencecenter.nl',
     url='https://github.com/NLeSC/fdp',
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,4 @@ setup(
     scripts=[
         'bin/fdp-run'
     ],
-    package_data={'fdp': ['schema/*.shacl']}
 )

--- a/setup.py
+++ b/setup.py
@@ -18,21 +18,21 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 setup(
-    name='fdp',
+    name='fairdatapoint',
     version=version['__version__'],
     description="Python implementation of FAIR Data Point",
     long_description=readme + '\n\n',
     long_description_content_type='text/markdown',
     author="Rajaram Kaliyaperumal, Arnold Kuzniar, Cunliang Geng, Carlos Martinez-Ortiz",
     author_email='c.martinez@esciencecenter.nl',
-    url='https://github.com/NLeSC/fdp',
+    url='https://github.com/NLeSC/fairdatapoint',
     packages=[
         'fdp',
     ],
     include_package_data=True,
     license="Apache Software License 2.0",
     zip_safe=False,
-    keywords='fdp',
+    keywords=['fdp', 'fairdatapoint'],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Found that the package name is `fdp` but not `fairdatapoint` after a release to pypi.
This PR is to fix the related settings. 
**Users will use `pip install fairdatapoint` to install it, but will still use `import fdp` to import it.** 