### PR TITLE
Update CI to install FDP from a distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ before_install:
 
 # command to install dependencies
 install:
-  - make install-test
+  - make dist
+  - make install-dist
 
 # command to run tests
 script:

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,8 @@ dist: clean
 	python setup.py sdist bdist_wheel
 	ls -l dist
 
+install-dist:
+	pip install `ls dist/*.gz`"[tests]"
+
 release:
 	python -m twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ dist: clean
 	ls -l dist
 
 install-dist:
-	pip install `ls dist/*.gz`"[tests]"
+	pip install --upgrade `ls dist/*.gz`"[tests]"
 
 release:
 	python -m twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ dist: clean
 	ls -l dist
 
 install-dist:
-	pip install --upgrade `ls dist/*.gz`"[tests]"
+	pip install `ls dist/*.gz`"[tests]"
 
 release:
 	python -m twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': ['prospector[with_pyroma]', 'yapf', 'isort'],
-        'tests': ['requests', 'pytest', 'pytest-cov', 'coveralls', 'pytest-datadir-ng'],
+        'tests': ['pytest>5.0', 'pytest-cov', 'coveralls', 'pytest-datadir-ng'],
         'docs': ['sphinx', 'sphinx_rtd_theme', 'recommonmark'],
     },
     scripts=[


### PR DESCRIPTION
- use pytest>5.0 due to the update of pytest-cov
- update CI to install FDP from a distribution but not a repo folder 