### PR TITLE
Expose port 80 in Dockerfile to solve issue when deploying using nginx-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ RUN pip install . && \
 
 ENV FDP_HOST=0.0.0.0
 ENV FDP_PORT=80
+EXPOSE 80
 
 CMD fdp-run ${FDP_HOST} ${FDP_PORT}


### PR DESCRIPTION
Expose the port 80 in the `Dockerfile` to solve issue https://github.com/NLeSC/fairdatapoint/issues/63 @CunliangGeng 

I allows to deploy the FDP services using a reverse nginx-proxy for docker: https://github.com/nginx-proxy/nginx-proxy