### PR TITLE
Update the swagger API deployment to use the base URL instead of /ui

### DIFF
--- a/fdp/fdp.py
+++ b/fdp/fdp.py
@@ -4,7 +4,7 @@ from fdp import config
 def create_app(host, port, graph_endpoint=None):
     config.init_fairgraph(host, port, graph_endpoint)
 
-    app = connexion.FlaskApp(__name__, specification_dir='openapi/', debug=True)
+    app = connexion.FlaskApp(__name__, specification_dir='openapi/', debug=True, options={"swagger_url": ""})
     options = {"swagger_ui": True}
     app.add_api('openapi.yaml',
             options=options,


### PR DESCRIPTION
Update the swagger API deployment to use the base URL instead of /ui to access the Swagger UI (it is less confusing than needing to know you need to go to /ui)

e.g. http://fdp.semanticscience.org/ instead of http://fdp.semanticscience.org/ui